### PR TITLE
Fix duplicate publicdatastats declaration

### DIFF
--- a/react-tailwind-app/src/components/PublicDataStats.tsx
+++ b/react-tailwind-app/src/components/PublicDataStats.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { PublicDataService } from '../services/publicDataService';
-import { PublicDataStats } from '../types/publicData';
+import { PublicDataStats as PublicDataStatsType } from '../types/publicData';
 
 interface PublicDataStatsProps {
   title?: string;
@@ -11,7 +11,7 @@ const PublicDataStats: React.FC<PublicDataStatsProps> = ({
   title = "공공데이터 통계", 
   showDetails = true 
 }) => {
-  const [stats, setStats] = useState<PublicDataStats | null>(null);
+  const [stats, setStats] = useState<PublicDataStatsType | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 

--- a/react-tailwind-app/src/services/mockApiServer.ts
+++ b/react-tailwind-app/src/services/mockApiServer.ts
@@ -28,12 +28,8 @@ const createApiResponse = <T>(data: T, success: boolean = true, message: string 
 const createErrorResponse = (message: string, code: string = 'API_ERROR') => {
   return {
     success: false,
-    error: {
-      code,
-      message,
-      timestamp: new Date().toISOString()
-    },
-    data: null
+    data: null,
+    message
   };
 };
 
@@ -421,7 +417,7 @@ export class MockApiServer {
       return {
         status: 'unhealthy',
         timestamp: new Date().toISOString(),
-        error: error.message
+        error: error instanceof Error ? error.message : 'Unknown error'
       };
     }
   }

--- a/react-tailwind-app/src/types/admin.ts
+++ b/react-tailwind-app/src/types/admin.ts
@@ -50,7 +50,7 @@ export interface SystemLog {
 
 export interface NotificationConfig {
   id: number;
-  type: 'new_bid' | 'urgent' | 'deadline';
+  type: 'new_bid' | 'urgent' | 'deadline' | 'achievement';
   channel: 'web' | 'email' | 'push';
   frequency: 'immediate' | 'daily' | 'weekly';
   recipients: string[];

--- a/react-tailwind-app/src/utils/mockData.ts
+++ b/react-tailwind-app/src/utils/mockData.ts
@@ -117,7 +117,8 @@ export const mockNotificationConfigs: NotificationConfig[] = [
     frequency: 'immediate',
     recipients: ['admin@example.com', 'user1@example.com'],
     isActive: true,
-    createdAt: '2024-01-01T00:00:00Z'
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z'
   },
   {
     id: 2,
@@ -126,7 +127,8 @@ export const mockNotificationConfigs: NotificationConfig[] = [
     frequency: 'immediate',
     recipients: ['admin@example.com'],
     isActive: true,
-    createdAt: '2024-01-01T00:00:00Z'
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z'
   },
   {
     id: 3,
@@ -135,7 +137,8 @@ export const mockNotificationConfigs: NotificationConfig[] = [
     frequency: 'daily',
     recipients: ['user1@example.com', 'user2@example.com'],
     isActive: false,
-    createdAt: '2024-01-01T00:00:00Z'
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z'
   }
 ];
 


### PR DESCRIPTION
Enable successful production build by resolving multiple TypeScript compilation errors.

The initial `TypeError: Duplicate declaration "PublicDataStats"` was due to a naming conflict between a component and an imported type. Fixing this revealed several other TypeScript errors, including missing types in interfaces, response type mismatches, unknown error handling, and missing required properties in mock data, all of which were addressed to achieve a clean build.

---

[Open in Web](https://www.cursor.com/agents?id=bc-44c53654-012c-4354-9361-ce23798c7a81) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-44c53654-012c-4354-9361-ce23798c7a81)