### PR TITLE
Fix useEffect dependency in public data list

### DIFF
--- a/react-tailwind-app/src/components/PublicDataList.tsx
+++ b/react-tailwind-app/src/components/PublicDataList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { PublicDataService } from '../services/publicDataService';
 import { PublicDataItem, PublicDataFilters } from '../types/publicData';
 
@@ -19,11 +19,7 @@ const PublicDataList: React.FC<PublicDataListProps> = ({
   const [filters, setFilters] = useState<PublicDataFilters>({});
   const [searchQuery, setSearchQuery] = useState('');
 
-  useEffect(() => {
-    loadPublicData();
-  }, [filters, limit]);
-
-  const loadPublicData = async () => {
+  const loadPublicData = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
@@ -41,7 +37,11 @@ const PublicDataList: React.FC<PublicDataListProps> = ({
     } finally {
       setLoading(false);
     }
-  };
+  }, [filters, limit]);
+
+  useEffect(() => {
+    loadPublicData();
+  }, [loadPublicData]);
 
   const handleSearch = async () => {
     if (!searchQuery.trim()) {


### PR DESCRIPTION
Fixes ESLint `react-hooks/exhaustive-deps` warning by memoizing `loadPublicData` with `useCallback` and adding it to the `useEffect` dependency array.

---

[Open in Web](https://www.cursor.com/agents?id=bc-29c0389b-3e00-437e-af78-65f06ebc917a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-29c0389b-3e00-437e-af78-65f06ebc917a)